### PR TITLE
bootstrap current element not parent

### DIFF
--- a/src/angular-elements.js
+++ b/src/angular-elements.js
@@ -14,7 +14,7 @@
             this._content = getContentNodes(this);
             this.angularModuleName = moduleName;
 
-            angular.bootstrap(this.parentNode, [this.angularModuleName]);
+            angular.bootstrap(this, [this.angularModuleName]);
 
             this.scope = angular.element(this).isolateScope() || angular.element(this.parentNode).scope();
             extend(this, this.scope);


### PR DESCRIPTION
I'm not sure if I'm missing a reason why this originally bootstrapped on the parent node, but doing this causes a problem when you put multiple sibling elements and attempt to register them as custom elements as in this example: (it causes a loop where jqlite clones the element and the parent is re-bootstrapped)

``` <html>

<body>

  <component-one name="Component One"></component-one>
  <component-two name="Component Two"></component-two>

  <script src="bower_components/angularjs/angular.min.js"></script>
  <script src="node_modules/angular-elements/src/angular-elements.js"></script>

  <script>
    var demoModule = angular.module('demo', []);

   demoModule.directive('componentOne', function() {
      return {
        restrict: 'E',
        scope: {},
        template: 'Component One'
      };
    });

    document.registerAngular('component-one', 'demo');

    demoModule.directive('componentTwo', function() {
      return {
        restrict: 'E',
        scope: {},
        template: 'Component Two'
      };
    });

    document.registerAngular('component-two', 'demo');

  </script>

</body>

</html>
```
